### PR TITLE
Set a static version for gson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <version>2.8.5</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Project wasn't compiling correctly due to no version being set for gson.

Old versions of gson required using a Gson object to convert primitive datatypes and strings before use, the latest version allows for just passing them in directly.

Signed-off-by: Zachary Heins <zackheins@gmail.com>