### PR TITLE
Expression data step

### DIFF
--- a/src/main/java/org/cbio/gdcpipeline/decider/StepDecider.java
+++ b/src/main/java/org/cbio/gdcpipeline/decider/StepDecider.java
@@ -10,7 +10,7 @@ import org.springframework.batch.core.job.flow.JobExecutionDecider;
  */
 public class StepDecider implements JobExecutionDecider {
     public enum STEP {
-        ALL, CLINICAL, MUTATION, CNA
+        ALL, CLINICAL, MUTATION, CNA, EXPRESSION
     }
 
     @Override
@@ -24,6 +24,9 @@ public class StepDecider implements JobExecutionDecider {
         }
         if (stepToRun.contains(STEP.CNA.toString())) {
             return new FlowExecutionStatus(STEP.CNA.toString());
+        }
+        if (stepToRun.contains(STEP.EXPRESSION.toString())) {
+            return new FlowExecutionStatus(STEP.EXPRESSION.toString());
         }
         return new FlowExecutionStatus(STEP.ALL.toString());
     }

--- a/src/main/java/org/cbio/gdcpipeline/model/ManifestFileData.java
+++ b/src/main/java/org/cbio/gdcpipeline/model/ManifestFileData.java
@@ -16,6 +16,8 @@ public class ManifestFileData {
     private String submitterSampleIds;
     private String datatype;
     private String dataCategory;
+    private String workflowType;
+    private List<String> sampleIds = new ArrayList<>();
 
     public List<String> getHeader(){
         List<String> header = new ArrayList<>();
@@ -100,5 +102,26 @@ public class ManifestFileData {
     
     public void setDataCategory(String dataCategory) {
         this.dataCategory = dataCategory;
+    }
+    
+    public String getWorkflowType() {
+        return workflowType;
+    }
+    
+    public void setWorkflowType(String workflowType) {
+        this.workflowType = workflowType;
+    }
+    
+    public List<String> getSampleIds() {
+        return sampleIds;
+    }
+    
+    public void setSampleIds(List<String> sampleIds) {
+        this.sampleIds.clear();
+        this.sampleIds.addAll(sampleIds);    
+    }
+    
+    public void addSampleId(String sampleId) {
+        sampleIds.add(sampleId);
     }
 }

--- a/src/main/java/org/cbio/gdcpipeline/processor/CnaProcessor.java
+++ b/src/main/java/org/cbio/gdcpipeline/processor/CnaProcessor.java
@@ -3,48 +3,24 @@ package org.cbio.gdcpipeline.processor;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cbio.gdcpipeline.model.cbio.CnaRecord;
-import org.cbio.gdcpipeline.model.genomenexus.GenomeNexusEnsemblResponse;
+import org.cbio.gdcpipeline.util.GenomeNexusCache;
 import org.springframework.batch.item.ItemProcessor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.MediaType;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
  * @author heinsz
  */
 public class CnaProcessor implements ItemProcessor<CnaRecord,CnaRecord>{
-    @Value("${cna.genomenexus.endpoint}")
-    private String url;
+    
+    @Autowired
+    private GenomeNexusCache genomeNexusCache;
 
-    @Value("${cna.geneId.field}")
-    private String geneId;
-
-    private RestTemplate restTemplate = new RestTemplate();
     private static Log LOG = LogFactory.getLog(CnaProcessor.class);
 
     @Override
     public CnaRecord process(CnaRecord record) throws Exception {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-        String ensembleGeneId = record.getEnsemblGeneId();
-        ensembleGeneId = ensembleGeneId.substring(0, ensembleGeneId.indexOf("."));
-        String payload = "?" + geneId + "=" + ensembleGeneId;
-        HttpEntity<String> entity = new HttpEntity<>(httpHeaders);
-        try {
-            ResponseEntity<GenomeNexusEnsemblResponse[]> response = restTemplate.exchange(url + payload, HttpMethod.GET, entity, GenomeNexusEnsemblResponse[].class);
-            record.setHugoSymbol(response.getBody()[0].getHugoSymbols().get(0));
-        }
-        catch (Exception e){
-            LOG.error("Failed to retreive gene annotation from genome nexus for gene " + ensembleGeneId);
-            record.setHugoSymbol(record.getEnsemblGeneId());
-        }
-
-
+        record.setHugoSymbol(genomeNexusCache.getHugoSymbolFromEnsembl(record.getEnsemblGeneId()));
         return record;
     }
 

--- a/src/main/java/org/cbio/gdcpipeline/reader/ExpressionReader.java
+++ b/src/main/java/org/cbio/gdcpipeline/reader/ExpressionReader.java
@@ -1,0 +1,153 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.cbio.gdcpipeline.reader;
+
+import java.io.BufferedReader;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbio.gdcpipeline.model.ManifestFileData;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.batch.item.NonTransientResourceException;
+import org.springframework.batch.item.ParseException;
+import org.springframework.batch.item.UnexpectedInputException;
+import org.springframework.beans.factory.annotation.Value;
+import org.cbio.gdcpipeline.util.CommonDataUtil;
+import java.io.File;
+import java.io.FileReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.commons.collections.map.MultiKeyMap;
+import org.cbio.gdcpipeline.util.GenomeNexusCache;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ *
+ * @author heinsz
+ */
+public class ExpressionReader implements ItemStreamReader<String> {
+
+    @Value("#{jobParameters[sourceDirectory]}")
+    private String sourceDir;
+    
+    @Value("#{jobExecutionContext[gdcManifestData]}")
+    private List<ManifestFileData> gdcManifestData;
+    
+    @Value("#{jobExecutionContext[gdcAliquotIdToSampleId]}")
+    private Map<String, String> gdcAliquotIdToSampleId;
+    
+    @Value("#{jobExecutionContext[gdcIdToSampleId]}")
+    private Map<String, String> gdcIdToSampleId;
+
+    @Value("#{jobExecutionContext[gdcUUIDToSampleId]}")
+    private Map<String, String> gdcUUIDToSampleId;   
+    
+    @Autowired
+    GenomeNexusCache genomeNexusCache;
+
+    private List<String> expressionRecords = new ArrayList<>();
+    private MultiKeyMap expressionMap = new MultiKeyMap();
+    private Set<String> genes = new HashSet<>();
+    private List<String> sampleIds = new ArrayList<>();
+    private static Log LOG = LogFactory.getLog(ExpressionReader.class);  
+    
+    private static final Pattern FILENAME_PATTERN = Pattern.compile("(\\S+)\\.htseq\\.counts.*");
+
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        for (ManifestFileData fileData : gdcManifestData) {
+            if (CommonDataUtil.GDC_TYPE.EXPRESSION.toString().equalsIgnoreCase(fileData.getDatatype().replace(" ", "_"))) {
+                File expressionFile;
+                LOG.info("Processing Expression file: " + fileData.getFilename());
+                try {
+                    Path path = Paths.get(sourceDir, fileData.getId(), fileData.getFilename());
+                        expressionFile = CommonDataUtil.extractCompressedFile(path.toFile());
+                }
+                catch (Exception e) {
+                    LOG.error("Failed to extract file");
+                    throw new ItemStreamException("Failed to process file");
+                }
+                
+                try {
+                    String sampleId = fileData.getSampleIds().get(0);
+                    if (gdcAliquotIdToSampleId.containsKey(sampleId.toUpperCase())) {
+                        readFile(expressionFile, executionContext, gdcAliquotIdToSampleId.get(sampleId));
+                    }
+                    else if (gdcIdToSampleId.containsKey(sampleId.toUpperCase())) {
+                        readFile(expressionFile, executionContext, gdcIdToSampleId.get(sampleId.toUpperCase()));
+                    }
+                    else if (gdcUUIDToSampleId.containsKey(sampleId.toUpperCase())) {
+                        readFile(expressionFile, executionContext, gdcUUIDToSampleId.get(sampleId.toUpperCase()));
+                    }                    
+                    else {
+                        LOG.error("Could not find id from filename " + fileData.getFilename());
+                    }
+                }
+                catch (Exception e) {
+                    LOG.error("Failed to read file " + fileData.getFilename());
+                }
+            }
+        }
+        generateExpressionRecords();
+        List<String> headerList = new ArrayList<>();
+        headerList.add("Hugo_Symbol");
+        for (String sampleId : sampleIds) {
+            headerList.add(sampleId);
+        }
+        executionContext.put("expressionHeader", headerList);        
+    }
+
+    @Override
+    public void update(ExecutionContext arg0) throws ItemStreamException {}
+
+    @Override
+    public void close() throws ItemStreamException {}
+
+    @Override
+    public String read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+        if (!expressionRecords.isEmpty()) {
+            return expressionRecords.remove(0);
+        }
+        return null;        
+    }
+    
+    private void readFile(File expressionFile, ExecutionContext e, String sampleId) throws Exception {
+        //TODO: There should be a cache for gene id mappings
+        BufferedReader br = new BufferedReader(new FileReader(expressionFile));
+        String line;
+        while ((line = br.readLine()) != null) {
+            if (line.startsWith("_")) {
+                continue;
+            }
+            String lineData[] = line.split("\t");
+            String geneId = lineData[0];
+            String value = lineData[1];
+            genes.add(genomeNexusCache.getHugoSymbolFromEnsembl(geneId));
+            //genes.add(geneId);
+            if (!sampleIds.contains(sampleId)) {
+                sampleIds.add(sampleId);
+            }   
+            expressionMap.put(geneId, sampleId, value);
+        }
+    }
+    
+    private void generateExpressionRecords() {
+        for (String gene : genes) {
+            String expressionRecord = gene;
+            for (String sampleId : sampleIds) {
+                expressionRecord = expressionRecord + "\t" + expressionMap.get(gene, sampleId);
+            }
+            expressionRecords.add(expressionRecord);
+        }
+    }
+}

--- a/src/main/java/org/cbio/gdcpipeline/step/ExpressionStep.java
+++ b/src/main/java/org/cbio/gdcpipeline/step/ExpressionStep.java
@@ -2,8 +2,6 @@ package org.cbio.gdcpipeline.step;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.cbio.gdcpipeline.model.cbio.CnaRecord;
-import org.cbio.gdcpipeline.processor.CnaProcessor;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
@@ -13,15 +11,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.cbio.gdcpipeline.reader.CnaReader;
-import org.cbio.gdcpipeline.writer.CnaWriter;
+import org.cbio.gdcpipeline.reader.ExpressionReader;
+import org.cbio.gdcpipeline.writer.ExpressionWriter;
 
 /**
  * @author heinsz
  */
 @EnableBatchProcessing
 @Configuration
-public class CnaStep {
+public class ExpressionStep {
     @Autowired
     StepBuilderFactory stepBuilderFactory;
 
@@ -35,29 +33,23 @@ public class CnaStep {
 
     @Bean
     @StepScope
-    public CnaReader cnaReader() {
-        return new CnaReader();
+    public ExpressionReader expressionReader() {
+        return new ExpressionReader();
     }
 
     @Bean
     @StepScope
-    public CnaProcessor cnaProcessor() {
-        return new CnaProcessor();
+    public ExpressionWriter expressionWriter() {
+        return new ExpressionWriter();
     }
 
-    @Bean
-    @StepScope
-    public CnaWriter cnaWriter() {
-        return new CnaWriter();
-    }
 
     @Bean
-    public Step cnaDataStep() {
-        return stepBuilderFactory.get("cnaDataStep")
-                .<CnaRecord, CnaRecord>chunk(chunkInterval)
-                .reader(cnaReader())
-                .processor(cnaProcessor())
-                .writer(cnaWriter())
+    public Step expressionDataStep() {
+        return stepBuilderFactory.get("expressionDataStep")
+                .<String, String>chunk(chunkInterval)
+                .reader(expressionReader())
+                .writer(expressionWriter())
                 .build();
     }
 }

--- a/src/main/java/org/cbio/gdcpipeline/util/CommonDataUtil.java
+++ b/src/main/java/org/cbio/gdcpipeline/util/CommonDataUtil.java
@@ -65,7 +65,8 @@ public class CommonDataUtil {
         BIOSPECIMEN("biospecimen_supplement"),
         CLINICAL("clinical_supplement"),
         MUTATION("masked_somatic_mutation"),
-        CNA("gene_level_copy_number_scores");
+        CNA("gene_level_copy_number_scores"),
+        EXPRESSION("gene_expression_quantification");
 
         private final String type;  
 
@@ -123,6 +124,7 @@ public class CommonDataUtil {
     }
     
     public static File extractCompressedFile(File extractFile) throws Exception {
+        temp_dir = createTempDirectory();
         if (isCompressedFile(extractFile)) {
             File tmp_file;
             try {
@@ -135,19 +137,20 @@ public class CommonDataUtil {
                 return extractFile;
             }
             try {
-                BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(tmp_file));
+                FileOutputStream fos = new FileOutputStream(tmp_file);
                 FileInputStream fis = new FileInputStream(extractFile);
                 if (extractFile.getName().endsWith(COMPRESSION_FORMAT.GZIP.toString())) {
-                    GZIPInputStream gzip = new GZIPInputStream(new BufferedInputStream(fis));
+                    GZIPInputStream gzip = new GZIPInputStream(fis);
+                    byte[] buffer = new byte[1024];
                     int readByte;
-                    while ((readByte = gzip.read()) > 0) {
-                        bos.write(readByte);
-                    }
+                    while ((readByte = gzip.read(buffer)) > 0) {
+                        fos.write(buffer, 0, readByte);
+                    }   
                     gzip.close();
                     Path path = Files.move(Paths.get(tmp_file.getAbsolutePath()), Paths.get(temp_dir.getAbsolutePath(), extractFile.getName().replace(COMPRESSION_FORMAT.GZIP.toString(), "")));
                     return new File(path.toUri());
                 }
-                bos.close();
+                fos.close();
             } catch (Exception e) {
                 e.printStackTrace();
                 deleteTempDir();
@@ -182,7 +185,7 @@ public class CommonDataUtil {
             }
             deleteDir(tmp_dir);
         }
-        tmp_dir.mkdir();
+            tmp_dir.mkdir();
         return tmp_dir;
     }
 

--- a/src/main/java/org/cbio/gdcpipeline/util/GenomeNexusCache.java
+++ b/src/main/java/org/cbio/gdcpipeline/util/GenomeNexusCache.java
@@ -1,0 +1,71 @@
+package org.cbio.gdcpipeline.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbio.gdcpipeline.model.genomenexus.GenomeNexusEnsemblResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ *
+ * @author heinsz
+ */
+public class GenomeNexusCache {
+    
+    private Map<String, GenomeNexusEnsemblResponse> genes = new HashMap<>();
+    private static Log LOG = LogFactory.getLog(GenomeNexusCache.class);
+    
+    @Value("${cna.geneId.field}")
+    private String geneField;           
+            
+    @Value("${cna.genomenexus.endpoint}")
+    private String url;
+    
+    private RestTemplate restTemplate = new RestTemplate();
+    
+    public GenomeNexusCache(){}    
+    
+    public String getHugoSymbolFromEnsembl(String geneId) {
+        if(!genes.containsKey(geneId)) {
+            genes.put(geneId, getDataFromGenomeNexus(geneId));
+        }
+        try {
+            return genes.get(geneId).getHugoSymbols().get(0);
+        }        
+        catch (NullPointerException e) {
+            LOG.error("No Hugo symbols for gene " + geneId);
+            return geneId;
+        }
+    }
+    
+    private GenomeNexusEnsemblResponse getDataFromGenomeNexus(String geneId) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);        
+        geneId = geneId.substring(0, geneId.indexOf("."));
+        String payload = "?" + geneField + "=" + geneId;
+        HttpEntity<String> entity = new HttpEntity<>(httpHeaders);
+        try {
+            LOG.info("Fetching gene data from GenomeNexus for " + geneId);
+            ResponseEntity<GenomeNexusEnsemblResponse[]> response = restTemplate.exchange(url + payload, HttpMethod.GET, entity, GenomeNexusEnsemblResponse[].class);
+            return response.getBody()[0];            
+        }
+        catch (Exception e){
+            LOG.error("Failed to retreive gene annotation from genome nexus for gene " + geneId);
+            GenomeNexusEnsemblResponse defaultGNResponse = new GenomeNexusEnsemblResponse();
+            List<String> ids = new ArrayList<>();
+            ids.add(geneId);
+            defaultGNResponse.setHugoSymbols(ids);
+            defaultGNResponse.setGeneId(geneId);
+            return defaultGNResponse;
+        }        
+    }
+}

--- a/src/main/java/org/cbio/gdcpipeline/writer/ExpressionWriter.java
+++ b/src/main/java/org/cbio/gdcpipeline/writer/ExpressionWriter.java
@@ -1,0 +1,57 @@
+package org.cbio.gdcpipeline.writer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamWriter;
+import org.springframework.batch.item.file.FlatFileHeaderCallback;
+import org.springframework.batch.item.file.FlatFileItemWriter;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ *
+ * @author heinsz
+ */
+public class ExpressionWriter implements ItemStreamWriter<String>{
+    @Value("#{jobParameters[outputDirectory]}")
+    private String outputDir;
+
+    @Value("${expression.data.file}")
+    private String expressionFile;       
+    
+    private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
+    
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        File outputFile = new File(outputDir, expressionFile);
+        List<String> header = (List<String>) executionContext.get("expressionHeader");
+        PassThroughLineAggregator aggr = new PassThroughLineAggregator();
+        flatFileItemWriter.setLineAggregator(aggr);
+        flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
+            @Override
+            public void writeHeader(Writer writer) throws IOException {
+                writer.write(StringUtils.join(header, "\t"));
+            }
+        });
+        flatFileItemWriter.setResource(new FileSystemResource(outputFile));
+        flatFileItemWriter.open(executionContext);
+    }
+
+    @Override
+    public void update(ExecutionContext arg0) throws ItemStreamException {}
+
+    @Override
+    public void close() throws ItemStreamException {}
+
+    @Override
+    public void write(List<? extends String> expressionRecords) throws Exception {
+        flatFileItemWriter.write(expressionRecords);
+    }
+    
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,5 +29,9 @@ cna.metadata.file=meta_cna.txt
 cna.genomenexus.endpoint=http://annotation.genomenexus.org/ensembl/transcript
 cna.geneId.field=geneId
 
+#################################### CNA ###################################################
+expression.data.file=data_expression.txt
+expression.metadata.file=expression_cna.txt
+
 #################################### Test #######################################################
 test.cancer.study.id=TCGA_BRCA


### PR DESCRIPTION
Genome nexus caching for ensembl ids
gzip input stream fixes
reader/writer for expression data
graphql query modifications for workflow (future use)

Signed-off-by: Zachary Heins <zackheins@gmail.com>