### PR TITLE
Fixes for mutation step

### DIFF
--- a/src/main/java/org/cbio/gdcpipeline/JobConfiguration/BatchConfiguration.java
+++ b/src/main/java/org/cbio/gdcpipeline/JobConfiguration/BatchConfiguration.java
@@ -57,7 +57,7 @@ public class BatchConfiguration {
     // TODO: Add metadata files for CNA and Expression
 //    @Resource(name = "cnaMetaDataStep")
 //    Step cnaMetaDataStep;
-    
+
     @Resource(name = "expressionDataStep")
     Step expressionDataStep;
 
@@ -70,7 +70,7 @@ public class BatchConfiguration {
                 .tasklet(setUpPipelineTasklet())
                 .build();
     }
-    
+
     @Bean
     public GenomeNexusCache genomeNexusCache() {
         return new GenomeNexusCache();
@@ -129,7 +129,7 @@ public class BatchConfiguration {
 //                .next(cnaMetaDataStep)
                 .build();
     }
-    
+
     @Bean
     public Flow expressionDataFlow() {
         return new FlowBuilder<Flow>("expressionDataFlow")
@@ -144,7 +144,7 @@ public class BatchConfiguration {
                 .start(clinicalDataFlow())
                 .next(mutationDataFlow())
                 .next(cnaDataFlow())
-                .next(expressionDataFlow())     
+                .next(expressionDataFlow())
                 .build();
     }
 

--- a/src/main/java/org/cbio/gdcpipeline/model/ensemblmap/EnsemblMap.java
+++ b/src/main/java/org/cbio/gdcpipeline/model/ensemblmap/EnsemblMap.java
@@ -1,0 +1,68 @@
+package org.cbio.gdcpipeline.model.ensemblmap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "mappings"
+})
+public class EnsemblMap {
+    @JsonProperty("mappings")
+    private List<Mapping> mappings = new ArrayList<Mapping>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    *
+    */
+    public EnsemblMap() {}
+
+    /**
+    *
+    * @param mappings
+    */
+    public EnsemblMap(List<Mapping> mappings) {
+        super();
+        this.mappings = mappings;
+    }
+
+    @JsonProperty("mappings")
+    public List<Mapping> getMappings() {
+        return mappings;
+    }
+
+    @JsonProperty("mappings")
+    public void setMappings(List<Mapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    public EnsemblMap withMappings(List<Mapping> mappings) {
+        this.mappings = mappings;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public EnsemblMap withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+}

--- a/src/main/java/org/cbio/gdcpipeline/model/ensemblmap/Mapped.java
+++ b/src/main/java/org/cbio/gdcpipeline/model/ensemblmap/Mapped.java
@@ -1,0 +1,166 @@
+package org.cbio.gdcpipeline.model.ensemblmap;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "end",
+    "assembly",
+    "coord_system",
+    "strand",
+    "start",
+    "seq_region_name"
+})
+public class Mapped {
+    @JsonProperty("end")
+    private Integer end;
+    @JsonProperty("assembly")
+    private String assembly;
+    @JsonProperty("coord_system")
+    private String coordSystem;
+    @JsonProperty("strand")
+    private Integer strand;
+    @JsonProperty("start")
+    private Integer start;
+    @JsonProperty("seq_region_name")
+    private String seqRegionName;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    *
+    */
+    public Mapped() {}
+
+    /**
+    *
+    * @param start
+    * @param assembly
+    * @param strand
+    * @param seqRegionName
+    * @param coordSystem
+    * @param end
+    */
+    public Mapped(Integer end, String assembly, String coordSystem, Integer strand, Integer start, String seqRegionName) {
+        super();
+        this.end = end;
+        this.assembly = assembly;
+        this.coordSystem = coordSystem;
+        this.strand = strand;
+        this.start = start;
+        this.seqRegionName = seqRegionName;
+    }
+
+    @JsonProperty("end")
+    public Integer getEnd() {
+        return end;
+    }
+
+    @JsonProperty("end")
+    public void setEnd(Integer end) {
+        this.end = end;
+    }
+
+    public Mapped withEnd(Integer end) {
+        this.end = end;
+        return this;
+    }
+
+    @JsonProperty("assembly")
+    public String getAssembly() {
+        return assembly;
+    }
+
+    @JsonProperty("assembly")
+    public void setAssembly(String assembly) {
+        this.assembly = assembly;
+    }
+
+    public Mapped withAssembly(String assembly) {
+        this.assembly = assembly;
+        return this;
+    }
+
+    @JsonProperty("coord_system")
+    public String getCoordSystem() {
+        return coordSystem;
+    }
+
+    @JsonProperty("coord_system")
+    public void setCoordSystem(String coordSystem) {
+        this.coordSystem = coordSystem;
+    }
+
+    public Mapped withCoordSystem(String coordSystem) {
+        this.coordSystem = coordSystem;
+        return this;
+    }
+
+    @JsonProperty("strand")
+    public Integer getStrand() {
+        return strand;
+    }
+
+    @JsonProperty("strand")
+    public void setStrand(Integer strand) {
+        this.strand = strand;
+    }
+
+    public Mapped withStrand(Integer strand) {
+        this.strand = strand;
+        return this;
+    }
+
+    @JsonProperty("start")
+    public Integer getStart() {
+        return start;
+    }
+
+    @JsonProperty("start")
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    public Mapped withStart(Integer start) {
+        this.start = start;
+        return this;
+    }
+
+    @JsonProperty("seq_region_name")
+    public String getSeqRegionName() {
+        return seqRegionName;
+    }
+
+    @JsonProperty("seq_region_name")
+    public void setSeqRegionName(String seqRegionName) {
+        this.seqRegionName = seqRegionName;
+    }
+
+    public Mapped withSeqRegionName(String seqRegionName) {
+        this.seqRegionName = seqRegionName;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Mapped withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+}

--- a/src/main/java/org/cbio/gdcpipeline/model/ensemblmap/Mapping.java
+++ b/src/main/java/org/cbio/gdcpipeline/model/ensemblmap/Mapping.java
@@ -1,0 +1,87 @@
+package org.cbio.gdcpipeline.model.ensemblmap;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "original",
+    "mapped"
+})
+public class Mapping {
+
+    @JsonProperty("original")
+    private Original original;
+    @JsonProperty("mapped")
+    private Mapped mapped;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    *
+    */
+    public Mapping() {}
+
+    /**
+    *
+    * @param original
+    * @param mapped
+    */
+    public Mapping(Original original, Mapped mapped) {
+        super();
+        this.original = original;
+        this.mapped = mapped;
+    }
+
+    @JsonProperty("original")
+    public Original getOriginal() {
+        return original;
+    }
+
+    @JsonProperty("original")
+    public void setOriginal(Original original) {
+        this.original = original;
+    }
+
+    public Mapping withOriginal(Original original) {
+    this.original = original;
+        return this;
+    }
+
+    @JsonProperty("mapped")
+    public Mapped getMapped() {
+        return mapped;
+    }
+
+    @JsonProperty("mapped")
+    public void setMapped(Mapped mapped) {
+        this.mapped = mapped;
+    }
+
+    public Mapping withMapped(Mapped mapped) {
+        this.mapped = mapped;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Mapping withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+}

--- a/src/main/java/org/cbio/gdcpipeline/model/ensemblmap/Original.java
+++ b/src/main/java/org/cbio/gdcpipeline/model/ensemblmap/Original.java
@@ -1,0 +1,167 @@
+package org.cbio.gdcpipeline.model.ensemblmap;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "strand",
+    "seq_region_name",
+    "start",
+    "end",
+    "assembly",
+    "coord_system"
+})
+public class Original {
+
+    @JsonProperty("strand")
+    private Integer strand;
+    @JsonProperty("seq_region_name")
+    private String seqRegionName;
+    @JsonProperty("start")
+    private Integer start;
+    @JsonProperty("end")
+    private Integer end;
+    @JsonProperty("assembly")
+    private String assembly;
+    @JsonProperty("coord_system")
+    private String coordSystem;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    *
+    */
+    public Original() {}
+
+    /**
+    *
+    * @param start
+    * @param assembly
+    * @param strand
+    * @param seqRegionName
+    * @param coordSystem
+    * @param end
+    */
+    public Original(Integer strand, String seqRegionName, Integer start, Integer end, String assembly, String coordSystem) {
+        super();
+        this.strand = strand;
+        this.seqRegionName = seqRegionName;
+        this.start = start;
+        this.end = end;
+        this.assembly = assembly;
+        this.coordSystem = coordSystem;
+    }
+
+    @JsonProperty("strand")
+    public Integer getStrand() {
+        return strand;
+    }
+
+    @JsonProperty("strand")
+    public void setStrand(Integer strand) {
+        this.strand = strand;
+    }
+
+    public Original withStrand(Integer strand) {
+    this.strand = strand;
+        return this;
+    }
+
+    @JsonProperty("seq_region_name")
+    public String getSeqRegionName() {
+        return seqRegionName;
+    }
+
+    @JsonProperty("seq_region_name")
+    public void setSeqRegionName(String seqRegionName) {
+        this.seqRegionName = seqRegionName;
+    }
+
+    public Original withSeqRegionName(String seqRegionName) {
+    this.seqRegionName = seqRegionName;
+        return this;
+    }
+
+    @JsonProperty("start")
+    public Integer getStart() {
+        return start;
+    }
+
+    @JsonProperty("start")
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    public Original withStart(Integer start) {
+        this.start = start;
+        return this;
+    }
+
+    @JsonProperty("end")
+    public Integer getEnd() {
+        return end;
+    }
+
+    @JsonProperty("end")
+    public void setEnd(Integer end) {
+        this.end = end;
+    }
+
+    public Original withEnd(Integer end) {
+        this.end = end;
+        return this;
+    }
+
+    @JsonProperty("assembly")
+    public String getAssembly() {
+        return assembly;
+    }
+
+    @JsonProperty("assembly")
+    public void setAssembly(String assembly) {
+        this.assembly = assembly;
+    }
+
+    public Original withAssembly(String assembly) {
+        this.assembly = assembly;
+        return this;
+    }
+
+    @JsonProperty("coord_system")
+    public String getCoordSystem() {
+        return coordSystem;
+    }
+
+    @JsonProperty("coord_system")
+    public void setCoordSystem(String coordSystem) {
+        this.coordSystem = coordSystem;
+    }
+
+    public Original withCoordSystem(String coordSystem) {
+    this.coordSystem = coordSystem;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Original withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+}

--- a/src/main/java/org/cbio/gdcpipeline/processor/MutationProcessor.java
+++ b/src/main/java/org/cbio/gdcpipeline/processor/MutationProcessor.java
@@ -1,5 +1,6 @@
 package org.cbio.gdcpipeline.processor;
 
+import java.util.ArrayList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cbioportal.annotator.Annotator;
@@ -12,10 +13,19 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.cbio.gdcpipeline.model.ensemblmap.EnsemblMap;
+import org.cbio.gdcpipeline.model.genomenexus.GenomeNexusEnsemblResponse;
 import org.cbioportal.annotator.GenomeNexusAnnotationFailureException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * @author Dixit Patel
@@ -26,6 +36,7 @@ public class MutationProcessor implements ItemProcessor<MutationRecord,Annotated
     private static Log LOG = LogFactory.getLog(MutationProcessor.class);
     @Value("#{jobParameters[isoformOverrideSource]}")
     private String isoformOverrideSource;
+    private RestTemplate restTemplate = new RestTemplate();
 
     @Autowired
     private Annotator annotator;
@@ -34,8 +45,11 @@ public class MutationProcessor implements ItemProcessor<MutationRecord,Annotated
     public AnnotatedRecord process(MutationRecord mutationRecord) throws Exception {
         mutationRecord.setTUMOR_SAMPLE_BARCODE(extractSampleId(mutationRecord.getTUMOR_SAMPLE_BARCODE()));
         mutationRecord.setMATCHED_NORM_SAMPLE_BARCODE(extractSampleId(mutationRecord.getMATCHED_NORM_SAMPLE_BARCODE()));
+        mutationRecord.setCHROMOSOME(normalizeChromosome(mutationRecord.getCHROMOSOME()));
+        if (mutationRecord.getNCBI_BUILD().equalsIgnoreCase("grch38")) {
+            mapToGrch37(mutationRecord);
+        }
         AnnotatedRecord annotatedRecord = annotateRecord(mutationRecord);
-        annotatedRecord.setCHROMOSOME(normalizeChromosome(annotatedRecord.getCHROMOSOME()));
         return annotatedRecord;
     }
 
@@ -55,7 +69,7 @@ public class MutationProcessor implements ItemProcessor<MutationRecord,Annotated
             validChrValues = new HashMap<>();
             for (int lc = 1; lc<=24; lc++) {
                 validChrValues.put(Integer.toString(lc),Integer.toString(lc));
-                validChrValues.put("CHR" + Integer.toString(lc),Integer.toString(lc));
+                validChrValues.put("CHR" + Integer.toString(lc), Integer.toString(lc));
             }
             validChrValues.put("X","23");
             validChrValues.put("CHRX","23");
@@ -64,7 +78,7 @@ public class MutationProcessor implements ItemProcessor<MutationRecord,Annotated
             validChrValues.put("NA","NA");
             validChrValues.put("MT","MT"); // mitochondria
         }
-        return validChrValues.get(chromosome);
+        return validChrValues.get(chromosome.toUpperCase());
     }
 
     private AnnotatedRecord annotateRecord(MutationRecord record) throws GenomeNexusAnnotationFailureException {
@@ -79,7 +93,38 @@ public class MutationProcessor implements ItemProcessor<MutationRecord,Annotated
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Client Error Exception. Failed to annotate a record from json! Sample: " + record.getTUMOR_SAMPLE_BARCODE() + " Variant: " + record.getCHROMOSOME() + ":" + record.getSTART_POSITION() + record.getREFERENCE_ALLELE() + ">" + record.getTUMOR_SEQ_ALLELE2());
             }
+        } catch (GenomeNexusAnnotationFailureException e) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Genome Nexus Annotation Failure. Failed to anotate a record from json! Sample: " + record.getTUMOR_SAMPLE_BARCODE() + " Variant: " + record.getCHROMOSOME() + ":" + record.getSTART_POSITION() + record.getREFERENCE_ALLELE() + ">" + record.getTUMOR_SEQ_ALLELE2());
+                annotatedRecord = new AnnotatedRecord(record);
+            }
         }
         return annotatedRecord;
+    }
+
+    private void mapToGrch37(MutationRecord mutationRecord) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        EnsemblMap mapping = new EnsemblMap();
+
+        Map<String, String> strandMap = new HashMap<>();
+        strandMap.put("+", "1");
+        strandMap.put("-", "0");
+        strandMap.put("1", "1");
+        strandMap.put("0", "0");
+
+        String payload = "/map/human/GRCh38/" + mutationRecord.getCHROMOSOME() + ":" + mutationRecord.getSTART_POSITION() + ".." + mutationRecord.getEND_POSITION() + ":" + strandMap.get(mutationRecord.getSTRAND()) + "/GRCh37?content-type=application-json";
+        HttpEntity<String> entity = new HttpEntity<>(httpHeaders);
+        try {
+            ResponseEntity<EnsemblMap> response = restTemplate.exchange("https://rest.ensembl.org" + payload, HttpMethod.GET, entity, EnsemblMap.class);
+            mapping = response.getBody();
+            mutationRecord.setSTART_POSITION(Integer.toString(mapping.getMappings().get(0).getMapped().getStart()));
+            mutationRecord.setEND_POSITION(Integer.toString(mapping.getMappings().get(0).getMapped().getEnd()));
+        }
+        catch (Exception e){
+            LOG.error("Failed to retreive gene mapping");
+            return;
+        }
     }
 }

--- a/src/main/java/org/cbio/gdcpipeline/writer/MutationWriter.java
+++ b/src/main/java/org/cbio/gdcpipeline/writer/MutationWriter.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
+import java.util.ArrayList;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -63,8 +64,10 @@ public class MutationWriter implements ItemStreamWriter<AnnotatedRecord> {
     private FieldExtractor<AnnotatedRecord> createFieldExtractor(AnnotatedRecord data) {
         BeanWrapperFieldExtractor<AnnotatedRecord> ext = new BeanWrapperFieldExtractor<>();
         List<String> fieldList = data.getHeaderWithAdditionalFields();
-        String[] fields = new String[fieldList.size()];
-        fields = data.getHeaderWithAdditionalFields().toArray(fields);
+        List<String> fieldsUpperCase = new ArrayList<>();
+        fieldList.forEach((item) -> fieldsUpperCase.add(item.toUpperCase()));
+        String[] fields = new String[fieldsUpperCase.size()];
+        fields = fieldsUpperCase.toArray(fields);
         ext.setNames(fields);
         return ext;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,8 +15,8 @@ clinical.metadata.sample.file=meta_clinical_sample.txt
 
 #################################### Mutation ###################################################
 mutation.data.file.prefix=data_
-mutation.metadata.file=meta_mutation.txt
-mutation.default.merged.maf.file=data_extended.maf
+mutation.metadata.file=meta_mutation_extended.txt
+mutation.default.merged.maf.file=data_mutation_extended.maf
 
 #################################### Genome Nexus ###################################################
 genomenexus.base=http://annotation.genomenexus.org/


### PR DESCRIPTION
- Calls the ensembl api to liftover GRCh38 -> GRCh37 so that genome nexus can annotate.
- Fixes the the way the writer extracts fields from `AnnotatedRecord`
- Chromosome normalization fix
Signed-off-by: Zachary Heins <zackheins@gmail.com>